### PR TITLE
[NO ISSUE] Confirm 추가

### DIFF
--- a/src/components/CustomDialog.jsx
+++ b/src/components/CustomDialog.jsx
@@ -34,7 +34,7 @@ export default function CustomDialog(props) {
 
   return (
     <Dialog open={open} onClose={onClose} aria-labelledby={dialogTitleID} {...dialogProps}>
-      <DialogTitle id={dialogTitleID}>{title}</DialogTitle>
+      {title && <DialogTitle id={dialogTitleID}>{title}</DialogTitle>}
       { isForm ? (
         <form onSubmit={onSubmit}>
           {dialogContent}

--- a/src/components/Popup.jsx
+++ b/src/components/Popup.jsx
@@ -1,20 +1,36 @@
 /* eslint-disable no-nested-ternary */
 import React from 'react';
 import { useRecoilState, useSetRecoilState } from 'recoil';
-import { popupState } from '../states/App';
+import { Button } from '@material-ui/core';
+import { popupState } from '@states/App';
 import CustomDialog from './CustomDialog';
 
+const noop = () => {};
+
 export default function Popup() {
-  const [{ open, title, content }, setPopup] = useRecoilState(popupState);
-  const closePopup = () => setPopup({ open: false, title, content });
+  const [popup, setPopup] = useRecoilState(popupState);
+  const { open, title, content, isConfirm = false, onConfirm = noop, onCancel = noop } = popup;
+
+  const closePopup = () => setPopup({ ...popup, open: false });
+
+  const dialogProps = isConfirm ? {
+    disableBackdropClick: true,
+    disableEscapeKeyDown: true,
+    buttons: [
+      <Button color="secondary" onClick={() => { closePopup(); onCancel(); }}>아니오</Button>,
+      <Button color="primary" onClick={() => { closePopup(); onConfirm(); }}>예</Button>,
+    ],
+  } : {
+    title,
+    onClose: closePopup,
+    onConfirm: closePopup,
+    confirmButtonText: '확인',
+  };
 
   return (
     <CustomDialog
       open={open}
-      title={title}
-      onClose={closePopup}
-      onConfirm={closePopup}
-      confirmButtonText="확인"
+      {...dialogProps}
     >
       {content}
     </CustomDialog>
@@ -27,5 +43,16 @@ export function useShowPopup(title, content) {
     open: true,
     title,
     content,
+  });
+}
+
+export function useShowConfirm(content, onConfirm, onCancel) {
+  const setPopup = useSetRecoilState(popupState);
+  setPopup({
+    open: true,
+    isConfirm: true,
+    content,
+    onConfirm,
+    onCancel,
   });
 }


### PR DESCRIPTION
`예`/`아니오` 로만 응답해야 하는 confirm 추가
선택에 따라 등록된 callback 호출

## Confirm 호출 방법
```js
import { useShowConfirm } from '@components/Popup';
useShowConfirm('적절한 질문', () => console.log('y'), () => console.log('n'));
```

## Confirm 예시
![image](https://user-images.githubusercontent.com/10149370/116729321-fd956080-aa21-11eb-9d50-38db506adca1.png)
