### PR TITLE
[NO ISSUE] Convert Popup: usePopup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,7 @@
     "arrow-parens": ["error", "as-needed"],
     "no-param-reassign": "off",
     "no-plusplus": "off",
+    "no-shadow": "off",
     "no-use-before-define": "off",
     "object-curly-newline": "off",
     "import/no-cycle": "off",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import './scss/main.scss';
-import { RecoilRoot } from 'recoil';
-import { CssBaseline } from '@material-ui/core';
 import Footer from './components/Footer';
 
 import Timetable from './views/Timetable';
@@ -10,7 +8,7 @@ import Login from './views/login/index';
 import PrivacyPolicy from './views/terms/PrivacyPolicy';
 import TermsOfService from './views/terms/TermsOfService';
 import Admin from './views/admin';
-import Popup from './components/Popup';
+import usePopup from './components/usePopup';
 import Notice from './views/notice';
 
 function ErrorPage() {
@@ -18,26 +16,24 @@ function ErrorPage() {
 }
 
 function App() {
+  const [Popup] = usePopup();
+
   return (
-    <div className="background-container">
-      <CssBaseline>
-        <RecoilRoot>
-          <Router>
-            <Switch>
-              <Route exact path="/" component={Timetable} />
-              <Route exact path="/login" component={Login} />
-              <Route exact path="/notice" component={Notice} />
-              <Route exact path="/admin" component={Admin} />
-              <Route path="/privacy_policy" component={PrivacyPolicy} />
-              <Route path="/terms_of_service" component={TermsOfService} />
-              <Route path="*" component={ErrorPage} />
-            </Switch>
-          </Router>
-          <Footer />
-          <Popup />
-        </RecoilRoot>
-      </CssBaseline>
-    </div>
+    <>
+      <Router>
+        <Switch>
+          <Route exact path="/" component={Timetable} />
+          <Route exact path="/login" component={Login} />
+          <Route exact path="/notice" component={Notice} />
+          <Route exact path="/admin" component={Admin} />
+          <Route path="/privacy_policy" component={PrivacyPolicy} />
+          <Route path="/terms_of_service" component={TermsOfService} />
+          <Route path="*" component={ErrorPage} />
+        </Switch>
+      </Router>
+      <Footer />
+      <Popup />
+    </>
   );
 }
 

--- a/src/components/usePopup.jsx
+++ b/src/components/usePopup.jsx
@@ -1,15 +1,33 @@
 /* eslint-disable no-nested-ternary */
 import React from 'react';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { Button } from '@material-ui/core';
 import { popupState } from '@states/App';
 import CustomDialog from './CustomDialog';
 
 const noop = () => {};
 
-export default function Popup() {
+export default function usePopup() {
   const [popup, setPopup] = useRecoilState(popupState);
   const { open, title, content, isConfirm = false, onConfirm = noop, onCancel = noop } = popup;
+
+  function showPopup(title, content) {
+    setPopup({
+      open: true,
+      title,
+      content,
+    });
+  }
+
+  function showConfirm(content, onConfirm, onCancel) {
+    setPopup({
+      open: true,
+      isConfirm: true,
+      content,
+      onConfirm,
+      onCancel,
+    });
+  }
 
   const closePopup = () => setPopup({ ...popup, open: false });
 
@@ -27,7 +45,7 @@ export default function Popup() {
     confirmButtonText: '확인',
   };
 
-  return (
+  const Popup = () => (
     <CustomDialog
       open={open}
       {...dialogProps}
@@ -35,24 +53,6 @@ export default function Popup() {
       {content}
     </CustomDialog>
   );
-}
 
-export function useShowPopup(title, content) {
-  const setPopup = useSetRecoilState(popupState);
-  setPopup({
-    open: true,
-    title,
-    content,
-  });
-}
-
-export function useShowConfirm(content, onConfirm, onCancel) {
-  const setPopup = useSetRecoilState(popupState);
-  setPopup({
-    open: true,
-    isConfirm: true,
-    content,
-    onConfirm,
-    onCancel,
-  });
+  return [Popup, showPopup, showConfirm];
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,11 +1,19 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './App';
+import { RecoilRoot } from 'recoil';
+import { CssBaseline } from '@material-ui/core';
 import reportWebVitals from './reportWebVitals';
+import App from './App';
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <div className="background-container">
+      <CssBaseline>
+        <RecoilRoot>
+          <App />
+        </RecoilRoot>
+      </CssBaseline>
+    </div>
   </React.StrictMode>,
   document.getElementById('root'),
 );

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 /* eslint-disable no-unused-vars */
 import axios from 'axios';
-import { useShowPopup } from '@components/Popup';
+import usePopup from '@components/usePopup';
 
 const { API_URL_BASE } = process.env;
 
@@ -67,8 +67,9 @@ axiosInstance.interceptors.request.use(
     return config;
   },
   error => {
+    const [, showPopup] = usePopup();
     console.error(error);
-    useShowPopup('에러', '서버를 찾을 수 없어요...');
+    showPopup('에러', '서버를 찾을 수 없어요...');
     return null;
   },
 );


### PR DESCRIPTION
`useShowPopup`, `useShowConfirm`을 호출할 때 [Hook의 규칙](https://ko.reactjs.org/docs/hooks-rules.html)을 위반하여 생기는 [문제](https://ko.reactjs.org/warnings/invalid-hook-call-warning.html)를 해결하기 위해 기존 Popup 구조를 개선함.

앞으로도 필요시 이런 형태로 일부 컴포넌트를 작성하고자 함.
컴포넌트마다 제공할 속성이나 메소드가 다양할 수 있으므로, 형태 통일을 위해 컴포넌트(이번의 경우 `Popup`)는 *0-index*로 제공.

```js
import usePopup from '@components/usePopup';

// ...
const [Popup, showPopup, showConfirm] = usePopup();
// ...
```